### PR TITLE
cargo: bump error-chain to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 authors = ["Stephen Demos <stephen.demos@coreos.com>"]
 
 [dependencies]
-error-chain = "0.10"
-users = "0.5"
 clap = "2.26"
-openssh-keys = "0.1"
+error-chain = { version = "0.11", default-features = false }
 fs2 = "0.4"
+openssh-keys = "0.1"
+users = "0.5"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ extern crate fs2;
 extern crate openssh_keys;
 extern crate users;
 
-#[allow(unused_doc_comment)]
 pub mod errors {
     error_chain!{
         foreign_links {


### PR DESCRIPTION
This updates error-chain to 0.11, cleaning a spurious clippy warning.
This also opts out from the default backtrace-sys feature, which can
be enabled by the consuming application instead.